### PR TITLE
2-section view of H

### DIFF
--- a/src/SimpleHypergraphs.jl
+++ b/src/SimpleHypergraphs.jl
@@ -5,9 +5,11 @@ using LightGraphs
 export Hypergraph, getvertices, gethyperedges, hg_load, hg_save
 export add_vertex!, add_hyperedge!
 export BipartiteView, shortest_path
+export TwoSectionView, shortest_path
 
 include("hypergraph.jl")
 include("bipartite.jl")
 include("io.jl")
+include("twosection.jl")
 
 end # module

--- a/src/twosection.jl
+++ b/src/twosection.jl
@@ -1,0 +1,85 @@
+"""
+    TwoSectionView{T<:Real} <: AbstractGraph{Int64}
+
+Create a 2-section view of a hypergraph `h`.
+Note this is a view - changes to the original hypergraph will be automatically reflected in the view.
+
+The 2-section view of a hypergraph is suitable for processing with the LightGraphs.jl package.
+Several LightGraphs methods are provided for the compability.
+
+"""
+struct TwoSectionView{T<:Real} <: AbstractGraph{Int}
+    h::Hypergraph{T}
+    function TwoSectionView{T}(h::Hypergraph{T}) where {T<:Real}
+        new(h)
+    end
+end
+
+LightGraphs.nv(t::TwoSectionView) = length(t.h.v2he)
+
+LightGraphs.vertices(t::TwoSectionView) = Base.OneTo(nv(t))
+
+LightGraphs.ne(t::TwoSectionView)::Int64 = 0.5*sum(length.(t.h.he2v) .* (length.(t.h.he2v) .- 1))
+
+"""
+    LightGraphs.all_neighbors(t::TwoSectionView, v::Integer)
+
+Returns N(v) (the vertex v is not included in N(v))
+"""
+function LightGraphs.all_neighbors(t::TwoSectionView, v::Integer)
+    neighbors = Set()
+    for he in keys(t.h.v2he[v])
+        union!(neighbors, keys(t.h.he2v[he]))
+    end
+    delete!(neighbors, v) #remove v from its neighborhood
+    convert(Array{Int64}, collect(neighbors)) #returns the corresponding array
+    #neighbors
+end
+
+function LightGraphs.has_edge(t::TwoSectionView, s, d)
+    he_s = keys(t.h.v2he[s])
+    he_d = keys(t.h.v2he[d])
+
+    !issetequal(intersect(he_s, he_d), Set())
+end
+
+LightGraphs.outneighbors(t::TwoSectionView, v::Integer) = LightGraphs.all_neighbors(t::TwoSectionView, v)
+
+LightGraphs.inneighbors(t::TwoSectionView, v::Integer) = LightGraphs.all_neighbors(t::TwoSectionView, v)
+
+"""
+    LightGraphs.SimpleGraph(t::TwoSectionView)
+
+Creates a `LightGraphs.SimpleGraph` representation of a `TwoSectionView` t.
+
+This creates a copy of the date. Note that the weights information is not stored
+in the created `SimpleGraph`.
+"""
+function LightGraphs.SimpleGraph(t::TwoSectionView)
+    g = SimpleGraph(nv(t))
+    for v in LightGraphs.vertices(t)
+        neighbors_v = LightGraphs.all_neighbors(t, v)
+        for neighbor in neighbors_v
+            add_edge!(g, v, neighbor)
+        end
+    end
+    g
+end
+
+LightGraphs.is_directed(t::TwoSectionView) = false
+
+"""
+    shortest_path(t::TwoSectionView,source::Int, target::Int)
+
+Finds a single shortest path in a graph `b` between vertices
+`source` and `target`.
+Note that if several paths of the same length exist, only one
+will be returned.
+
+"""
+function shortest_path(t::TwoSectionView,source::Int, target::Int)
+    @boundscheck source <= length(t.h.v2he) || throw(BoundsError(t.h.v2he, source))
+    @boundscheck target <= length(t.h.v2he) || throw(BoundsError(t.h.v2he, target))
+    dj = dijkstra_shortest_paths(t, source)
+    enumerate_paths(dj)[target]#[1:2:end]
+end

--- a/src/twosection.jl
+++ b/src/twosection.jl
@@ -81,5 +81,5 @@ function shortest_path(t::TwoSectionView,source::Int, target::Int)
     @boundscheck source <= length(t.h.v2he) || throw(BoundsError(t.h.v2he, source))
     @boundscheck target <= length(t.h.v2he) || throw(BoundsError(t.h.v2he, target))
     dj = dijkstra_shortest_paths(t, source)
-    enumerate_paths(dj)[target]#[1:2:end]
+    enumerate_paths(dj)[target]
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using Test, SimpleHypergraphs
 import LightGraphs
 
-h = hg_load("data/test1.hgf", Int)
+h = hg_load("test/data/test1.hgf", Int)
 @test size(h) == (4, 4)
 m = Matrix(h)
 @test m == h
@@ -9,10 +9,10 @@ m = Matrix(h)
             2       3       nothing nothing
             nothing nothing 5       nothing
             nothing nothing 6       nothing]
-mktemp("data") do path, _
+mktemp("test/data") do path, _
     println(path)
     hg_save(path, h)
-    @test read(path, String) == replace(read("data/test1.hgf", String), "\r\n" => "\n")
+    @test read(path, String) == replace(read("test/data/test1.hgf", String), "\r\n" => "\n")
 end
 
 h1 = Hypergraph{Float64}(5,4)
@@ -31,8 +31,6 @@ add_vertex!(h2;hyperedges=Dict(2=>6.5))
 add_hyperedge!(h2;vertices=Dict(2 => 3.5, 4 => 4.5))
 add_hyperedge!(h2;vertices=Dict(3:5 .=> (2.5,4.5,5.5)))
 @test h1 == h2
-
-
 
 b = BipartiteView{Float64}(h1)
 

--- a/test/twosectiontest.jl
+++ b/test/twosectiontest.jl
@@ -1,0 +1,38 @@
+using Test, SimpleHypergraphs
+import LightGraphs
+
+h = Hypergraph{Float64}(5,4)
+h[1:3,1] .= 1.5
+h[3,4] = 2.5
+h[2,3] = 3.5
+h[4,3:4] .= 4.5
+h[5,4] = 5.5
+h[5,2] = 6.5
+
+t = TwoSectionView{Float64}(h)
+
+@test LightGraphs.nv(t) == 5
+@test LightGraphs.ne(t) == 7
+
+@test sort(LightGraphs.all_neighbors(t, 1)) == [2,3]
+@test sort(LightGraphs.outneighbors(t, 5)) == [3,4]
+@test sort(LightGraphs.inneighbors(t, 4)) == [2,3,5]
+
+@test sum(LightGraphs.adjacency_matrix(LightGraphs.SimpleGraph(t))) == 14
+
+@test shortest_path(t,1,5) == [1,3,5]
+
+@test LightGraphs.is_weakly_connected(t) == true
+
+@test SimpleHypergraphs.add_vertex!(h) == 6
+@test add_hyperedge!(h) == 5
+h[5,5] = 1
+h[6,5] = 1
+
+@test shortest_path(t,1,6) == [1,3,5,6]
+
+@test LightGraphs.nv(t) == 6
+@test LightGraphs.ne(t) == 8
+@test sort(LightGraphs.outneighbors(t, 5)) == [3,4, 6]
+
+@test sum(LightGraphs.adjacency_matrix(LightGraphs.SimpleGraph(t))) == 16

--- a/test/twosectiontest.jl
+++ b/test/twosectiontest.jl
@@ -33,6 +33,6 @@ h[6,5] = 1
 
 @test LightGraphs.nv(t) == 6
 @test LightGraphs.ne(t) == 8
-@test sort(LightGraphs.outneighbors(t, 5)) == [3,4, 6]
+@test sort(LightGraphs.outneighbors(t, 5)) == [3,4,6]
 
 @test sum(LightGraphs.adjacency_matrix(LightGraphs.SimpleGraph(t))) == 16


### PR DESCRIPTION
According to the definition of the 2-section of a hypergraph, defined in: 
Alain Bretto. 2013. Hypergraph Theory: An Introduction. Springer Publishing Company, Incorporated (page 25), 

we have implemented a 2-section view of H following the structure of the BipartiteView.

In particular:
 - the function LightGraphs.all_neighbors(t::TwoSectionView, v::Integer) 
     - returns N(v)\{v};
     - returns an Array{Int64} for compatibility with the BipartiteView (thus performing a conversion from Set to Array).

- According to the 2-section definition, function LightGraphs.SimpleGraph(t::TwoSectionView) does not add any self-loop. This means that if a hyperedge contains a single vertex, this information is lost in the 2-section view. How should we manage this situation? 
 




