### PR TITLE
Hypergraphs building models

### DIFF
--- a/src/SimpleHypergraphs.jl
+++ b/src/SimpleHypergraphs.jl
@@ -15,6 +15,7 @@ export set_vertex_meta!, get_vertex_meta
 export set_hyperedge_meta!, get_hyperedge_meta
 export BipartiteView, shortest_path
 export TwoSectionView
+export get_twosection_adjacency_mx, get_twosection_weighted_adjacency_mx
 
 export Abstract_HG_format, HGF_Format, JSON_Format
 export hg_load, hg_save
@@ -26,6 +27,8 @@ export findcommunities
 export random_walk
 export get_connected_components
 
+export random_model, random_kuniform_model, random_dregular_model, random_preferential_model
+
 export HyperNetX, GraphBased
 export draw
 
@@ -36,13 +39,13 @@ const pynull = PyNULL()
 
 function __init__()
     plot_ok = true
-    try 
+    try
 		copy!(nx, pyimport("networkx"))
     catch e
 		@warn "Python networkx not found. Plotting functionality of HyperNetX will not work."
 		plot_ok = false
 	end
-	try 
+	try
 		copy!(hnx, pyimport("hypernetx"))
     catch e
 		@warn "Python HyperNetX not found. Plotting functionality will not work."
@@ -53,7 +56,7 @@ end
 function support_hypernetx()
     return ((SimpleHypergraphs.nx !=  SimpleHypergraphs.pynull) &&
            (SimpleHypergraphs.hnx !=  SimpleHypergraphs.pynull))
-  
+
 end
 
 include("hypergraph.jl")
@@ -61,8 +64,10 @@ include("bipartite.jl")
 include("io.jl")
 include("twosection.jl")
 include("modularity.jl")
+include("models.jl")
 
 include("viz/drawing.jl")
 include("viz/widget.jl")
+
 
 end # module

--- a/src/models.jl
+++ b/src/models.jl
@@ -18,7 +18,7 @@ the algorithm computes - for each hyperedge *he={1,...,m}* -
 a random number *s ϵ [1, n]* (i.e. the hyperedge size).
 Then, the algorithm selects uniformly at random *s* vertices from *V* to be added in *he*.
 """
-function random_model(nVertices, nEdges)
+function random_model(nVertices::Int, nEdges::Int)
     mx = Matrix{Union{Nothing,Bool}}(nothing, nVertices,nEdges)
     for e in 1:size(mx,2)
         nv = rand(1:size(mx,1))
@@ -42,7 +42,7 @@ Generates a *k*-uniform hypergraph, i.e. an hypergraph where each hyperedge has 
 **The Algorithm**
 The algorithm proceeds as the *randomH*, forcing the size of each hyperedge equal to *k*.
 """
-function random_kuniform_model(nVertices, nEdges, k)
+function random_kuniform_model(nVertices::Int, nEdges::Int, k::Int)
     mx = Matrix{Union{Nothing,Bool}}(nothing, nVertices,nEdges)
     for e in 1:size(mx,2)
         nv = k
@@ -50,10 +50,10 @@ function random_kuniform_model(nVertices, nEdges, k)
     end
 
     h = Hypergraph(mx)
-    if all(length.(h.v2he) .== k)
+    if all(length.(h.he2v) .== k)
         return h
     else
-        return random_kuniform_model(nVertices, nEdges)
+        return random_kuniform_model(nVertices, nEdges, k)
     end
 end
 
@@ -68,7 +68,7 @@ The algorithm exploits the *k*-uniform approach described for the *random_kunifo
 to build a *d*-regular hypergraph *H* having *nVertices* nodes and *nEdges* edges.
 It returns the hypergraph H^* dual of *H*.
 """
-function random_dregular_model(nVertices, nEdges, d)
+function random_dregular_model(nVertices::Int, nEdges::Int, d::Int)
     mx = Matrix{Union{Nothing,Bool}}(nothing, nVertices,nEdges)
 
     for v in 1:size(mx,1)
@@ -77,10 +77,10 @@ function random_dregular_model(nVertices, nEdges, d)
     end
 
     h = Hypergraph(mx)
-    if all(length.(h.he2v) .== d)
+    if all(length.(h.v2he) .== d)
         return h
     else
-        return random_dregular_model(nVertices, nEdges)
+        return random_dregular_model(nVertices, nEdges, d)
     end
 end
 
@@ -92,15 +92,16 @@ Generate a hypergraph with a preferential attachment rule between nodes, as pres
 *Avin, C., Lotker, Z., and Peleg, D.Random preferential attachment hyper-graphs.Computer Science 23(2015).*
 
 **The Algorithm**
-The algorithm starts with a random graph with 5 nodes and 5 edges.
+The algorithm starts with a random graph with 5 nodes and 5 edges. For this reason,
+the generated random graph has at least 5 nodes and 5 edges.
 It iteratively adds a node or a edge, according to a given parameter *p*,
 which defines the probability of creating a new node or a new hyperedge.
 
 More in detail, the connections with the new node/hyperedge are generated according to
 a preferential attachment policy defined by _p_.
 """
-function random_preferential_model(nVertices, p)
-    H₀ = random_model(10,10)
+function random_preferential_model(nVertices::Int, p::Real)
+    H₀ = random_model(5,5)
     H = H₀
     while nhv(H) < nVertices
         r = rand()

--- a/src/models.jl
+++ b/src/models.jl
@@ -77,10 +77,10 @@ end
 
 
 """
-    random_preferential_model(nVertices, p)
+    random_preferential_model(nVertices::Int, p::Real; H = random_model(5,5))
 
 Generate a hypergraph with a preferential attachment rule between nodes, as presented in
-*Avin, C., Lotker, Z., and Peleg, D.Random preferential attachment hyper-graphs.Computer Science 23(2015).*
+*Avin, C., Lotker, Z., and Peleg, D.Random preferential attachment hyper-graphs. Computer Science 23 (2015).*
 
 # The Algorithm
 
@@ -91,9 +91,12 @@ which defines the probability of creating a new node or a new hyperedge.
 
 More in detail, the connections with the new node/hyperedge are generated according to
 a preferential attachment policy defined by _p_.
+
+The so-built hypergraph will have `nVertices` vertices.
+
+The starting hypergraph can be instantiated as preferred.
 """
-function random_preferential_model(nVertices::Int, p::Real)
-    H = random_model(5,5)
+function random_preferential_model(nVertices::Int, p::Real; H = random_model(5,5))
     while nhv(H) < nVertices
         r = rand()
         y = rand(1:nhv(H))
@@ -101,11 +104,11 @@ function random_preferential_model(nVertices::Int, p::Real)
         if r < p
             v = SimpleHypergraphs.add_vertex!(H)
             push!(Y,v=>true)
-            for v in nextNodes(H,y-1)
+            for v in next_nodes(H,y-1)
                 push!(Y,v)
             end
         else
-            for v in nextNodes(H,y)
+            for v in next_nodes(H,y)
                 push!(Y,v)
             end
         end
@@ -115,7 +118,12 @@ function random_preferential_model(nVertices::Int, p::Real)
 end
 
 
-function nextNodes(h,size)
+"""
+    next_nodes(h::Hypergraph, size::Int)
+
+Selects nodes to add to a hyperedge.
+"""
+function next_nodes(h::Hypergraph, size::Int)
     nodes = Dict{Int, Bool}()
 
     ids = collect(1:nhv(h))
@@ -140,7 +148,7 @@ function nextNodes(h,size)
             end
         end
 
-        nodes[bucket]=true
+        nodes[bucket] = true
         deleteat!(ids, index)
     end
     nodes

--- a/src/models.jl
+++ b/src/models.jl
@@ -47,16 +47,9 @@ The algorithm proceeds as the *randomH*, forcing the size of each hyperedge equa
 function random_kuniform_model(nVertices::Int, nEdges::Int, k::Int)
     mx = Matrix{Union{Nothing,Bool}}(nothing, nVertices,nEdges)
     for e in 1:size(mx,2)
-        nv = k
-        mx[sample(1:size(mx,1), nv;replace=false), e] .= true
+        mx[sample(1:size(mx,1), k;replace=false), e] .= true
     end
-
-    h = Hypergraph(mx)
-    if all(length.(h.he2v) .== k)
-        return h
-    else
-        return random_kuniform_model(nVertices, nEdges, k)
-    end
+    Hypergraph(mx)
 end
 
 
@@ -73,18 +66,10 @@ It returns the hypergraph H^* dual of *H*.
 """
 function random_dregular_model(nVertices::Int, nEdges::Int, d::Int)
     mx = Matrix{Union{Nothing,Bool}}(nothing, nVertices,nEdges)
-
     for v in 1:size(mx,1)
-        ne = d
-        mx[v, sample(1:size(mx,2), ne;replace=false)] .= true
+        mx[v, sample(1:size(mx,2), d;replace=false)] .= true
     end
-
-    h = Hypergraph(mx)
-    if all(length.(h.v2he) .== d)
-        return h
-    else
-        return random_dregular_model(nVertices, nEdges, d)
-    end
+    Hypergraph(mx)
 end
 
 
@@ -105,8 +90,7 @@ More in detail, the connections with the new node/hyperedge are generated accord
 a preferential attachment policy defined by _p_.
 """
 function random_preferential_model(nVertices::Int, p::Real)
-    H₀ = random_model(5,5)
-    H = H₀
+    H = random_model(5,5)
     while nhv(H) < nVertices
         r = rand()
         y = rand(1:nhv(H))

--- a/src/models.jl
+++ b/src/models.jl
@@ -1,0 +1,155 @@
+"""
+    Models for random hypergraphs building:
+        * random model
+        * k-uniform model
+        * d-uniform model
+        * preferential-attachment
+"""
+
+
+"""
+    random_model(nVertices, nEdges)
+
+Generate a *random* hypergraph without any structural constraints.
+
+**The Algorithm**
+Given two integer parameters *nVertices* and *nEdges* (the number of nodes and hyperedges, respectively),
+the algorithm computes - for each hyperedge *he={1,...,m}* -
+a random number *s ϵ [1, n]* (i.e. the hyperedge size).
+Then, the algorithm selects uniformly at random *s* vertices from *V* to be added in *he*.
+"""
+function random_model(nVertices, nEdges)
+    mx = Matrix{Union{Nothing,Bool}}(nothing, nVertices,nEdges)
+    for e in 1:size(mx,2)
+        nv = rand(1:size(mx,1))
+        mx[sample(1:size(mx,1), nv;replace=false), e] .= true
+    end
+
+    h = Hypergraph(mx)
+    if all(length.(h.v2he) .> 0)
+        return h
+    else
+        return random_model(nVertices, nEdges)
+    end
+end
+
+
+"""
+    random_kuniform_model(nVertices, nEdges, k)
+
+Generates a *k*-uniform hypergraph, i.e. an hypergraph where each hyperedge has size *k*.
+
+**The Algorithm**
+The algorithm proceeds as the *randomH*, forcing the size of each hyperedge equal to *k*.
+"""
+function random_kuniform_model(nVertices, nEdges, k)
+    mx = Matrix{Union{Nothing,Bool}}(nothing, nVertices,nEdges)
+    for e in 1:size(mx,2)
+        nv = k
+        mx[sample(1:size(mx,1), nv;replace=false), e] .= true
+    end
+
+    h = Hypergraph(mx)
+    if all(length.(h.v2he) .== k)
+        return h
+    else
+        return random_kuniform_model(nVertices, nEdges)
+    end
+end
+
+
+"""
+    random_dregular_model(nVertices, nEdges, d)
+
+Generates a *d*-regular hypergraph, where each node has degree *d*.
+
+**The Algorithm**
+The algorithm exploits the *k*-uniform approach described for the *random_kuniform_model* method
+to build a *d*-regular hypergraph *H* having *nVertices* nodes and *nEdges* edges.
+It returns the hypergraph H^* dual of *H*.
+"""
+function random_dregular_model(nVertices, nEdges, d)
+    mx = Matrix{Union{Nothing,Bool}}(nothing, nVertices,nEdges)
+
+    for v in 1:size(mx,1)
+        ne = d
+        mx[v, sample(1:size(mx,2), ne;replace=false)] .= true
+    end
+
+    h = Hypergraph(mx)
+    if all(length.(h.he2v) .== d)
+        return h
+    else
+        return random_dregular_model(nVertices, nEdges)
+    end
+end
+
+
+"""
+    random_preferential_model(nVertices, p)
+
+Generate a hypergraph with a preferential attachment rule between nodes, as presented in
+*Avin, C., Lotker, Z., and Peleg, D.Random preferential attachment hyper-graphs.Computer Science 23(2015).*
+
+**The Algorithm**
+The algorithm starts with a random graph with 5 nodes and 5 edges.
+It iteratively adds a node or a edge, according to a given parameter *p*,
+which defines the probability of creating a new node or a new hyperedge.
+
+More in detail, the connections with the new node/hyperedge are generated according to
+a preferential attachment policy defined by _p_.
+"""
+function random_preferential_model(nVertices, p)
+    H₀ = random_model(10,10)
+    H = H₀
+    while nhv(H) < nVertices
+        r = rand()
+        y = rand(1:nhv(H))
+        Y = Dict{Int,Bool}()
+        if r < p
+            v = SimpleHypergraphs.add_vertex!(H)
+            push!(Y,v=>true)
+            for v in nextNodes(H,y-1)
+                push!(Y,v)
+            end
+        else
+            for v in nextNodes(H,y)
+                push!(Y,v)
+            end
+        end
+            SimpleHypergraphs.add_hyperedge!(H, vertices=Y)
+    end
+    H
+end
+
+
+function nextNodes(h,size)
+    nodes = Dict{Int, Bool}()
+
+    ids = collect(1:nhv(h))
+    degrees = length.(h.v2he)
+
+    for s=1:size
+        psum = collect(1:length(ids))
+
+        psum[1] = degrees[ids[1]]
+        for j=2:length(ids)
+            psum[j] = psum[j-1] + degrees[ids[j]]
+        end
+
+        number = rand(1:psum[length(psum)])
+        bucket = -1
+        index=1
+        for i=1:length(psum)
+            if number <= psum[i]
+                bucket = ids[i]
+                index = i
+                break
+            end
+        end
+
+        push!(nodes, bucket=>true)
+        deleteat!(ids, index)
+    end
+    nodes
+end

--- a/src/models.jl
+++ b/src/models.jl
@@ -12,7 +12,8 @@
 
 Generate a *random* hypergraph without any structural constraints.
 
-**The Algorithm**
+# The Algorithm
+
 Given two integer parameters *nVertices* and *nEdges* (the number of nodes and hyperedges, respectively),
 the algorithm computes - for each hyperedge *he={1,...,m}* -
 a random number *s ϵ [1, n]* (i.e. the hyperedge size).
@@ -39,7 +40,8 @@ end
 
 Generates a *k*-uniform hypergraph, i.e. an hypergraph where each hyperedge has size *k*.
 
-**The Algorithm**
+# The Algorithm
+
 The algorithm proceeds as the *randomH*, forcing the size of each hyperedge equal to *k*.
 """
 function random_kuniform_model(nVertices::Int, nEdges::Int, k::Int)
@@ -63,7 +65,8 @@ end
 
 Generates a *d*-regular hypergraph, where each node has degree *d*.
 
-**The Algorithm**
+# The Algorithm
+
 The algorithm exploits the *k*-uniform approach described for the *random_kuniform_model* method
 to build a *d*-regular hypergraph *H* having *nVertices* nodes and *nEdges* edges.
 It returns the hypergraph H^* dual of *H*.
@@ -91,7 +94,8 @@ end
 Generate a hypergraph with a preferential attachment rule between nodes, as presented in
 *Avin, C., Lotker, Z., and Peleg, D.Random preferential attachment hyper-graphs.Computer Science 23(2015).*
 
-**The Algorithm**
+# The Algorithm
+
 The algorithm starts with a random graph with 5 nodes and 5 edges. For this reason,
 the generated random graph has at least 5 nodes and 5 edges.
 It iteratively adds a node or a edge, according to a given parameter *p*,

--- a/src/models.jl
+++ b/src/models.jl
@@ -20,7 +20,10 @@ a random number *s ϵ [1, n]* (i.e. the hyperedge size).
 Then, the algorithm selects uniformly at random *s* vertices from *V* to be added in *he*.
 """
 function random_model(nVertices::Int, nEdges::Int)
-    mx = Matrix{Union{Nothing,Bool}}(nothing, nVertices,nEdges)
+    mx = Matrix{Union{Nothing,Bool}}(nothing, nVertices, nEdges)
+    if nEdges == 0
+        return Hypergraph(nVertices, nEdges)
+    end
     for e in 1:size(mx,2)
         nv = rand(1:size(mx,1))
         mx[sample(1:size(mx,1), nv;replace=false), e] .= true
@@ -117,9 +120,9 @@ function nextNodes(h,size)
 
     ids = collect(1:nhv(h))
     degrees = length.(h.v2he)
-
+    
     for s=1:size
-        psum = collect(1:length(ids))
+        psum = Vector{Int}(undef, length(ids))
 
         psum[1] = degrees[ids[1]]
         for j=2:length(ids)
@@ -127,7 +130,7 @@ function nextNodes(h,size)
         end
 
         number = rand(1:psum[length(psum)])
-        bucket = -1
+        local bucket::Int
         index=1
         for i=1:length(psum)
             if number <= psum[i]
@@ -137,7 +140,7 @@ function nextNodes(h,size)
             end
         end
 
-        push!(nodes, bucket=>true)
+        nodes[bucket]=true
         deleteat!(ids, index)
     end
     nodes

--- a/src/models.jl
+++ b/src/models.jl
@@ -118,7 +118,7 @@ function random_preferential_model(nVertices::Int, p::Real)
                 push!(Y,v)
             end
         end
-            SimpleHypergraphs.add_hyperedge!(H, vertices=Y)
+        SimpleHypergraphs.add_hyperedge!(H, vertices=Y)
     end
     H
 end

--- a/src/twosection.jl
+++ b/src/twosection.jl
@@ -156,7 +156,6 @@ LightGraphs.zero(::Type{TwoSectionView{T}}) where T = TwoSectionView(Hypergraph{
                                 replace_weights::Union{Nothing,Real}=nothing ) where {T<:Real, V, E}
 
     Returns an adjacency matrix for a two section view of a hypergraph `h`.
-    If the
 """
 function get_twosection_adjacency_mx(h::Hypergraph{T,V,E}; count_self_loops::Bool=false,
                                      replace_weights::Union{Nothing,Real}=nothing ) where {T<:Real, V, E}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,8 +35,6 @@ h1[5,2] = 6.5
 
     H∂ = random_preferential_model(20, 0.5)
     @test nhv(H∂) == 20
-
-
 end;
 
 @testset "SimpleHypergraphs Hypergraph      " begin
@@ -162,7 +160,6 @@ end;
     setindex!(h1_0, nothing, 1, 1)
     @test h1_0[1,1] == nothing
     @test_throws BoundsError setindex!(h1_0, nothing, 10, 9)
-
 end;
 
 @testset "SimpleHypergraphs BipartiteView   " begin
@@ -267,7 +264,6 @@ end;
     @test minimum([sum((h_from_g .== true)[:,n]) for n in 1:6] .== 2)
     @test LightGraphs.modularity(g,[1,1,2,2,3,3,4,4]) ≈ modularity(h_from_g, Set.([[1,2],[3,4],[5,6],[7,8]]))
     @test LightGraphs.SimpleGraphs.fadj(g) == LightGraphs.SimpleGraphs.fadj(TwoSectionView(h_from_g))
-
 end;
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,14 @@ h1[5,2] = 6.5
     @test  all(length.(Hᵣ.v2he) .> 0)
     @test  all(length.(Hᵣ.v2he) .<= 5)
 
+    Hᵣ2 = random_model(5,0)
+    add_hyperedge!(Hᵣ2;vertices=Dict(2 => true, 4 => true))
+    @test nhv(Hᵣ2) == 5
+    @test nhe(Hᵣ2) == 1
+
+    Hᵣ3  = random_model(5,1)
+    @test nhe(Hᵣ3) == 1
+   
     Hκ = random_kuniform_model(5, 5, 3)
     @test nhv(Hκ) == 5
     @test nhe(Hκ) == 5

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,29 @@ h1[4,3:4] .= 4.5
 h1[5,4] = 5.5
 h1[5,2] = 6.5
 
+@testset "SimpleHypergraphs building models    " begin
+
+    Hᵣ = random_model(5,5)
+    @test nhv(Hᵣ) == 5
+    @test nhe(Hᵣ) == 5
+    @test  all(length.(Hᵣ.v2he) .> 0)
+    @test  all(length.(Hᵣ.v2he) .<= 5)
+
+    Hκ = random_kuniform_model(5, 5, 3)
+    @test nhv(Hκ) == 5
+    @test nhe(Hκ) == 5
+    @test all(length.(Hκ.he2v) .== 3)
+
+    Hδ = random_dregular_model(5, 5, 3)
+    @test nhv(Hδ) == 5
+    @test nhe(Hδ) == 5
+    @test all(length.(Hδ.v2he) .== 3)
+
+    H∂ = random_preferential_model(20, 0.5)
+    @test nhv(H∂) == 20
+
+
+end;
 
 @testset "SimpleHypergraphs Hypergraph      " begin
 
@@ -244,6 +267,7 @@ end;
     @test minimum([sum((h_from_g .== true)[:,n]) for n in 1:6] .== 2)
     @test LightGraphs.modularity(g,[1,1,2,2,3,3,4,4]) ≈ modularity(h_from_g, Set.([[1,2],[3,4],[5,6],[7,8]]))
     @test LightGraphs.SimpleGraphs.fadj(g) == LightGraphs.SimpleGraphs.fadj(TwoSectionView(h_from_g))
+
 end;
 
 


### PR DESCRIPTION
Support for hypergraphs generation in the model.jl file.

This version provides the following models:
- **Random**, given two integer values (_n_ and _m_), generates a completely random hypergraph with _n_ nodes and _m_ hyperedges;
 - **Random k-uniform**,  given three integer values (_n_,_m_,_k_), generates a random hypergraph with _n_ nodes and _m_ hyperedges, where each hyperedge has a size equal to _k_;
 - **Random d-regular**,  given three integer values (_n_,_m_,_d_), generates a random hypergraph with _n_ nodes and _m_ hyperedges, where each node has degree equal to _d_;
 - **Random preferential**,  given an integer value (_n_) and a real probability value (_p_), generates a random hypergraph with _n_ nodes, where each node has degree proportional to a preferential attachment probability _p_. As described in the paper: Avin, C., Lotker, Z., and Peleg, D.Random preferential attachment hyper-graphs.Computer Science 23 (2015).

**_Usage_**

```julia
#generates a random Hypergraph{Bool}(5,5)
h = random_model(5,5) 

#generates a random k-uniform Hypergraph{Bool}(5,5)
h = random_kuniform_model(5, 5, 3)

#generates a random d-regular Hypergraph{Bool}(5,5)
h = random_dregular_model(5, 5, 3) 

#generates a random with preferential attachment 
#Hypergraph{Bool}(20,m), where m is the number of hyperedges computed by the algorithm
h = random_preferential_model(20, 0.5) 
```